### PR TITLE
Additional test for emphasis parsing

### DIFF
--- a/CommonMarkSharp.Tests/CommonMarkSharp.Tests.csproj
+++ b/CommonMarkSharp.Tests/CommonMarkSharp.Tests.csproj
@@ -51,6 +51,7 @@
   </Choose>
   <ItemGroup>
     <Compile Include="CharSetTests.cs" />
+    <Compile Include="EmphasisTests.cs" />
     <Compile Include="Helpers.cs" />
     <Compile Include="Specs.cs">
       <AutoGen>True</AutoGen>

--- a/CommonMarkSharp.Tests/EmphasisTests.cs
+++ b/CommonMarkSharp.Tests/EmphasisTests.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace CommonMarkSharp.Tests
+{
+    [TestClass]
+    public class EmphasisTests
+    {
+        private CommonMark _cm = new CommonMark();
+
+        [TestMethod]
+        [TestCategory("Inlines - Emphasis and strong emphasis")]
+        public void UnderscoreWithinEmphasis()
+        {
+            // See https://github.com/jgm/stmd/issues/51 for additional info
+            // The rule is that inlines are processed left-to-right
+
+            // Arrange
+            var commonMark = Helpers.Normalize("*_*_");
+            var expected = Helpers.Normalize("<p><em>_</em>_</p>");
+
+            // Act
+            var actual = _cm.RenderAsHtml(commonMark);
+
+            // Assert
+            Helpers.LogValue("Actual", actual);
+            Assert.AreEqual(Helpers.Tidy(expected), Helpers.Tidy(actual));
+        }
+    }
+}

--- a/CommonMarkSharp.Tests/EmphasisTests.cs
+++ b/CommonMarkSharp.Tests/EmphasisTests.cs
@@ -30,5 +30,24 @@ namespace CommonMarkSharp.Tests
             Helpers.LogValue("Actual", actual);
             Assert.AreEqual(Helpers.Tidy(expected), Helpers.Tidy(actual));
         }
+
+        [TestMethod]
+        [TestCategory("Inlines - Emphasis and strong emphasis")]
+        public void UnderscoreWithinEmphasis2()
+        {
+            // See https://github.com/jgm/stmd/issues/51 for additional info
+            // The rule is that inlines are processed left-to-right
+
+            // Arrange
+            var commonMark = Helpers.Normalize("*a _b _c d_ e*");
+            var expected = Helpers.Normalize("<p><em>a <em>b _c d</em> e</em></p>");
+
+            // Act
+            var actual = _cm.RenderAsHtml(commonMark);
+
+            // Assert
+            Helpers.LogValue("Actual", actual);
+            Assert.AreEqual(Helpers.Tidy(expected), Helpers.Tidy(actual));
+        }
     }
 }


### PR DESCRIPTION
The markdown `*_*_` should be parsed to `<p><em>_</em>_</p>` because

<blockquote>
<strong>6 Inlines</strong>
Inlines are parsed sequentially from the beginning of the character stream to the end (left to right, in left-to-right languages). 
</blockquote>
